### PR TITLE
add ability to select columns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuackIO"
 uuid = "7b8617ff-c43a-4c37-a28b-ad5a1791f8ae"
 authors = ["Alexander Plavin <alexander@plav.in>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/ext/SQLCollectionsExt.jl
+++ b/ext/SQLCollectionsExt.jl
@@ -1,16 +1,18 @@
 module SQLCollectionsExt
 
 using QuackIO
-using QuackIO: kwarg_val_to_db_incomma, kwargs_to_db_comma, DBInterface, DuckDB, columntable
+using QuackIO: kwarg_val_to_db_incomma, kwargs_to_db_comma, DBInterface, DuckDB,
+    columntable, _selectstring, duckdb_filetype_func
 using SQLCollections: SQLCollection, FunSQL as F
 
-function QuackIO._read_file(::Type{SQLCollection}, file, duckdb_func::String; kwargs...)
-    qstr = "select * from $duckdb_func($(kwarg_val_to_db_incomma(file)) $(kwargs_to_db_comma(kwargs))) limit 0"
-    @debug "$duckdb_func query" qstr
-	conn = DuckDB.DB()
+function QuackIO.read_file(::Type{SQLCollection}, file, filetype::Symbol; kwargs...)
+    duckdb_func = duckdb_filetype_func(filetype)
+    qstr = _selectstring(file, duckdb_func; kwargs...)
+    @debug("running query string:", qstr)
+    conn = DuckDB.DB()
     colnames = DBInterface.execute(conn, qstr) |> columntable |> keys |> collect
 	ffunc = getproperty(F.Fun, "$duckdb_func(? $(kwargs_to_db_comma(kwargs)))")
-	SQLCollection(conn, F.From(ffunc(F.Lit(file)); columns=colnames))
+    SQLCollection(conn, F.From(ffunc(F.Lit(file)); columns=colnames))
 end
 
 # XXX: should upstream

--- a/ext/SQLCollectionsExt.jl
+++ b/ext/SQLCollectionsExt.jl
@@ -5,7 +5,7 @@ using QuackIO: kwarg_val_to_db_incomma, kwargs_to_db_comma, DBInterface, DuckDB,
     columntable, _selectstring, duckdb_filetype_func
 using SQLCollections: SQLCollection, FunSQL as F
 
-function QuackIO.read_file(::Type{SQLCollection}, file, filetype::Symbol; kwargs...)
+function QuackIO.read_file(::Type{SQLCollection}, file, filetype::Union{Symbol,Nothing}=nothing; kwargs...)
     duckdb_func = duckdb_filetype_func(filetype)
     qstr = _selectstring(file, duckdb_func; kwargs...)
     @debug("running query string:", qstr)

--- a/src/QuackIO.jl
+++ b/src/QuackIO.jl
@@ -16,16 +16,91 @@ function write_table(file, tbl; kwargs...)
 	DBInterface.execute(con, qstr)
 end
 
-read_csv(fmt, file; kwargs...) = _read_file(fmt, file, "read_csv"; kwargs...)
-read_parquet(fmt, file; kwargs...) = _read_file(fmt, file, "read_parquet"; kwargs...)
-read_json(fmt, file; kwargs...) = _read_file(fmt, file, "read_json"; kwargs...)
+"""
+    QuackIO.read_csv(fmt, file; kwargs...)
 
-function _read_file(fmt, file, duckdb_func::String; kwargs...)
-    qstr = "select * from $duckdb_func($(kwarg_val_to_db_incomma(file)) $(kwargs_to_db_comma(kwargs)))"
-    @debug "$duckdb_func query" qstr
+Read the CSV file `file` into the data structure `fmt`.  Equivalent to `read_file(fmt, file, :csv; kwargs...)`,
+see [`read_file`](@ref).
+"""
+read_csv(fmt, file; kwargs...) = read_file(fmt, file, :csv; kwargs...)
+
+"""
+    QuackIO.read_parquet(fmt, file; kwargs...)
+
+Read the parquet file `file` into the data structure `fmt`.  Equivalent to `read_file(fmt, file, :parquet; kwargs...)`,
+see [`read_file`](@ref).
+"""
+read_parquet(fmt, file; kwargs...) = read_file(fmt, file, :parquet; kwargs...)
+
+"""
+    QuackIO.read_json(fmt, file; kwargs...)
+
+Read the JSON file `file` into the data structure `fmt`.  Equivalent to `read_file(fmt, file, :json; kwargs...)`,
+see [`read_file`](@ref).
+"""
+read_json(fmt, file; kwargs...) = read_file(fmt, file, :json; kwargs...)
+
+_colname_sql_string(col::Union{Symbol,AbstractString}) = string(col)
+_colname_sql_string(col::Pair) = string(_colname_sql_string(col[1]), " AS ", _colname_sql_string(col[2]))
+
+function columnsstring(cols)
+    if isnothing(cols) || isempty(cols)
+        "*"
+    else
+        join(map(_colname_sql_string, cols), ", ")
+    end
+end
+
+function duckdb_filetype_func(filetype::Symbol)
+    if filetype == :parquet
+        "read_parquet"
+    elseif filetype == :csv
+        "read_csv"
+    elseif filetype == :json
+        "read_json"
+    elseif filetype == :unknown  # this should let DDB guess
+        ""
+    else
+        throw(ArgumentError("unrecognized file type $filetype"))
+    end
+end
+
+function _selectstring(file, duckdb_func::AbstractString; select=nothing, limit::Integer=-1, kwargs...)
+    cols = columnsstring(select)
+    readstr = if isempty(duckdb_func)
+        kwarg_val_to_db(file)
+    else
+        string(duckdb_func, "(", kwarg_val_to_db_incomma(file), " ", kwargs_to_db_comma(kwargs), ")")
+    end
+    qstr = "SELECT $cols FROM $readstr"
+    limit ≥ 0 && (qstr = string(qstr, '\n', "LIMIT ", limit))
+    qstr
+end
+
+function selectstring(file, filetype::Symbol; kwargs...)
+    duckdb_func = duckdb_filetype_func(filetype)
+    _selectstring(file, duckdb_func; kwargs...)
+end
+
+"""
+    QuackIO.read_file(fmt, filename, filetype::Symbol=:unknown; select=nothing, kwargs...)
+
+Read a table from file or files `filename` into the data structure `fmt` using DuckDB.  Examples of `fmt`
+include `DataFrame`, `StructArray`, `columntable` and `rowtable`.
+
+`filetype` can be `:parquet`, `:csv`, `:json` or `:unknown`.  If `:unknown`, DuckDB will attempt to guess
+the filetype, this is equivalent to passing the file name only to DuckDB without an explicit read function.
+
+`select` can be `nothing` or an iterator.  If `nothing` or an empty iterator, all columns will be read.  A
+non-empty iterator must have elements that are strings, `Symbol` or `Pair` of string or `Symbol`.  Only the
+specified columns will be read, `Pair`s will provide aliases for the read columns.
+"""
+function read_file(fmt, file, filetype::Symbol=:unknown; kwargs...)
+    qstr = selectstring(file, filetype; kwargs...)
+    @debug("running query string:", qstr)
     matf = fmt isa Function ? fmt : Tables.materializer(fmt)
     table = DBInterface.execute(DuckDB.DB(), qstr) |> matf
-    _read_metadata!(table, file; duckdb_func)
+    _read_metadata!(table, file, filetype)
     return table
 end
 
@@ -63,8 +138,8 @@ function _table_metadata_to_kwargs(file, tbl; kwargs)
     return (;)
 end
 
-function _read_metadata!(table, file; duckdb_func)
-    if DataAPI.metadatasupport(typeof(table)).write && lowercase(duckdb_func) == "read_parquet"
+function _read_metadata!(table, file, filetype::Symbol)
+    if DataAPI.metadatasupport(typeof(table)).write && filetype == :parquet
         qstr = """
             select *
             from parquet_kv_metadata($(kwarg_val_to_db_incomma(file)))

--- a/src/QuackIO.jl
+++ b/src/QuackIO.jl
@@ -68,6 +68,13 @@ end
 function _selectstring(file, duckdb_func::AbstractString; select=nothing, limit::Integer=-1, kwargs...)
     cols = columnsstring(select)
     readstr = if isempty(duckdb_func)
+        if !isempty(kwargs)
+            throw(ArgumentError("""
+            A specific file type was not selected, but additional keyword arguments were passed.
+            These arguments should only be used when a specific file type is selected as they
+            are passed to the DuckDB `read_` function.
+            """))
+        end
         kwarg_val_to_db(file)
     else
         string(duckdb_func, "(", kwarg_val_to_db_incomma(file), " ", kwargs_to_db_comma(kwargs), ")")

--- a/src/QueryStrings.jl
+++ b/src/QueryStrings.jl
@@ -1,4 +1,0 @@
-module QueryStrings
-
-
-end

--- a/src/QueryStrings.jl
+++ b/src/QueryStrings.jl
@@ -1,0 +1,4 @@
+module QueryStrings
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,10 @@ using TestItemRunner
     @test isequal(read_csv(columntable, csvfname, select=(:a, :b)), (a=[1,2], b=["x", "yz"]))
     @test isequal(read_csv(columntable, csvfname, select=("a"=>"c", "b"=>"d")), (c=[1,2], d=["x", "yz"]))
 
+    tbl2 = NamedTuple{(Symbol("a b"),)}(([1,2],))
+    write_table(csvfname, tbl2; format=:csv)
+    @test isequal(read_csv(columntable, csvfname, select=("a b"=>"c d",)), NamedTuple{(Symbol("c d"),)}(([1,2],)))
+
     write_table(csvfname, tbl; format=:csv)
     @test readlines(csvfname) == ["a,b,c", "1,x,1.0", "2,yz,"]
     @test isequal(read_csv(columntable, csvfname), tbl)


### PR DESCRIPTION
This PR adds a few features:
- `read_file` as a first-class function that also allows DuckDB to use it's automatic file type inference.
- Ability to specify columns and aliases in `SELECT` statements.
- Some docstrings.
- A little function reorganization to accommodate the above changes without introducing code repetition.

Columns are selected with the keyword argument `select`.  Originally I was going to make this `columns`, but this conflicts with the argument passed to `read_filetype` within DDB SQL.  I am admittedly confused about why DDB takes these two different types of arguments (i.e. `columns` and the usual `SELECT` arguments), so it's not totally clear to me that I'm doing the right thing by introducing an argument separate from `columns`, but it does seem that specifying columns directly to the `SELECT` statement will be a lot more flexible in the long run.